### PR TITLE
Fixed incorrect line numbers in links

### DIFF
--- a/content/blog/2015/2015-10-17.md
+++ b/content/blog/2015/2015-10-17.md
@@ -173,14 +173,14 @@ a příznak **autoRebuild**.
 
 K přegenerování dojde když:
 
-* [se změní jméno](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L52)
-* dojde k expiraci a `autoRebuild` je [TRUE](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L95)
-* upravíme [zaindexovaný soubor](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L98)
+* [se změní jméno](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L55)
+* dojde k expiraci a `autoRebuild` je [TRUE](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L98)
+* upravíme [zaindexovaný soubor](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L101)
 
-Při vytváření containeru se [vytvoří i soubor \*.meta](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L76),
-který nese informaci o [použitých souborech](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L113-L114).
+Při vytváření containeru se [vytvoří i soubor \*.meta](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L79),
+který nese informaci o [použitých souborech](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L116-L117).
 
-Pokud se nějaký soubor v průběhu změní, [kontrolní součet](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L98)
+Pokud se nějaký soubor v průběhu změní, [kontrolní součet](https://github.com/nette/di/blob/v2.3/src/DI/ContainerLoader.php#L101)
 nebude sedět a dojde k přegenerování.
 
 Pokud používáte Nette\Configurator, tak [ten vytváří název containeru](https://github.com/nette/bootstrap/blob/v2.3/src/Bootstrap/Configurator.php#L216)
@@ -188,7 +188,7 @@ podle parametrů a souborů (configů).
 
 #### Neznámý počet parametrů
 
-Tuto vlastnost využijeme hlavně v metodě [CompilerExtension::afterCompile](https://github.com/nette/di/blob/v2.3/src/DI/CompilerExtension.php#L127-L133).
+Tuto vlastnost využijeme hlavně v metodě [CompilerExtension::afterCompile](https://github.com/nette/di/blob/v2.3/src/DI/CompilerExtension.php#L128-L134).
 
 Uvažujme tento kód:
 


### PR DESCRIPTION
There may have been some shifting back then in `v2.3`